### PR TITLE
Remove --populate arguments and old gnupg package deployment

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -2,15 +2,15 @@
 
 ### Is BlackArch Linux the right pentesting distribution for me?
 
-BlackArch Linux is a Linux pentesting distribution based on ArchLinux. If you're not familiar with ArchLinux, or Linux in general, we strongly suggest you avoid BlackArch due to the learning curve for new users.
+BlackArch Linux is a Linux pentesting distribution based on Arch Linux. If you're not familiar with Arch Linux, or Linux in general, we strongly suggest you avoid BlackArch due to the learning curve for new users.
 
 ### Where do I start with BlackArch?
 
-You must first get an ISO on the [downloads](https://blackarch.org/downloads.html) page and install it by following the instructions of the installation script. You can find a [installation guide](/install_guide) to show the step by step process. If you encounter any problems and need help, the best place to ask is our [Matrix channel](https://matrix.to/#/%23BlackArch:matrix.org).
+You must first get an ISO on the [downloads](https://blackarch.org/downloads.html) page and install it by following the instructions of the installation script. You can find an [installation guide](/install_guide) to show the step by step process. If you encounter any problems and need help, the best place to ask is our [Matrix channel](https://matrix.to/#/%23BlackArch:matrix.org).
 
 ### Is BlackArch Linux up to date?
 
-BlackArch is constantly being updated and offers the latest packages available on Github. We release a new ISO four times a year (quarterly). These new images contain packages that are up to date, and usually include bug fixes. If you find any package that is outdated and wish to see it up to date, please report it as an issue on our [Github](https://github.com/blackarch/blackarch) repository.
+BlackArch is constantly being updated and offers the latest packages available on Github. We release a new ISO four times a year (quarterly). These new images contain packages that are up to date, and usually include bug fixes. If you find any package that is outdated and wish to see it up to date, please report it as an issue on our [Github](https://github.com/BlackArch/blackarch) repository.
 
 ### How can I fetch/install the latest update available?
 
@@ -20,7 +20,7 @@ By simply running `pacman -Syu --needed --overwrite='*' blackarch`. This command
 
 It could happen for a wide range of reasons. Below you will find a few suggestions.
 
-* You don't have an internet connection (as you can imagine, a rare problem and can be verified quickly).
+* You don't have an Internet connection (as you can imagine, it is a rare problem and can be verified quickly).
 * You may have a DNS problem, that can't resolve `pgp.mit.edu` accordingly. Please check your DNS settings (`pgp.mit.edu` works best with `8.8.8.8` DNS Server).
 * You may have a network issue, different from the above one, which is hard for us to help since it can be a myriad of things e.g. DNS caching.
 * You may have a clock/time issue.
@@ -28,13 +28,13 @@ It could happen for a wide range of reasons. Below you will find a few suggestio
 * If you're connected through a VPN, try to temporarily disable it and run `strap.sh` again.
 * Your keyring signatures may be out of date, this can be resolved by running `pacman -Sy && pacman -S archlinux-keyring blackarch-keyring`
 
-After testing al lthe items described above, if you stil have problems using `strap.sh`, try the options below:
+After testing all the items described above, if you stil have problems using `strap.sh`, try the options below:
 
 1st option:
 ```
 rm -rf /etc/pacman.d/gnupg
 pacman-key --init
-pacman-key --populate archlinux blackarch
+pacman-key --populate
 pacman-key --update --keyserver keyserver.ubuntu.com
 ```
 
@@ -52,23 +52,23 @@ sh strap.sh
 3rd option:
 You could try to temporarily switch to another mirror:
 `sudoedit /etc/pacman.d/blacakrch-mirrorlist`
-It's very important to follow the suggestions above as well as checking the [ArchLinux Wiki](https://wiki.archlinux.org) to assist you as needed. If you still encounter any problems; pay us a visit at [#BlackArch](https://matrix.to/#/%23BlackArch:matrix.org).
+It's very important to follow the suggestions above as well as checking the [Arch Linux Wiki](https://wiki.archlinux.org) to assist you as needed. If you still encounter any problems, pay us a visit at [#BlackArch](https://matrix.to/#/%23BlackArch:matrix.org).
 
 4th option:
-**Easiest Option** Update the Arch Linux and BlackArch Linux keyrings which will refresh all the keys and automatically resolve curruption.
+**Easiest Option** Update the Arch Linux and BlackArch Linux keyrings which will refresh all the keys and automatically resolve corruption.
 ```
 pacman -S archlinux-keyring blackarch-keyring && pacman -Syu
 ```
 
 ### Where can I get help for a problem that I'm facing?
 
-Depending on the problem you're facing, you can visit our [Github](https://github.com/blackarch/blackarch) and submit an issue on our issue page, such as:
-* [BlackArch repository](https://github.com/blackarch/blackarch/issues): related to our packages. For example: a package hasn't been updated or failed to run.
-* [BlackArch Site repository](https://github.com/blackarch/blackarch-site/issues): related to our website. For example: If a link is broken or an image isn't loading.
+Depending on the problem you're facing, you can visit our [Github](https://github.com/BlackArch/blackarch) and submit an issue on our issue page, such as:
+* [BlackArch repository](https://github.com/BlackArch/blackarch/issues): related to our packages. For example: a package hasn't been updated or failed to run.
+* [BlackArch Site repository](https://github.com/BlackArch/blackarch-site/issues): related to our website. For example: If a link is broken or an image isn't loading.
 * [BlackArch Installer repository](https://github.com/blackarch/blackarch-installer/issues): related to our installer. For example: the installation failed or you can not boot after a successful installation.
 
-You can also take some time to browse our other [repositories](https://guthub.com/blackarch).
-If you still cannot find a solution to your problem, visit our [Matrix channel](https://matrix.to/#/%23BlackArch:matrix.org) and ask for help. But please be advised, BlackArch users are in different parts of the globe (different time zones). Therefor, be patient. Ask your question clearly and wait for a reply.
+You can also take some time to browse our other [repositories](https://github.com/BlackArch).
+If you still cannot find a solution to your problem, visit our [Matrix channel](https://matrix.to/#/%23BlackArch:matrix.org) and ask for help. But please be advised, BlackArch users are in different parts of the globe (different time zones). Therefore, be patient. Ask your question clearly and wait for a reply.
 
 ### How can I contribute to BlackArch?
 
@@ -77,4 +77,4 @@ If you would like to help us with anything, visit our [Matrix channel](https://m
 
 ### Troubleshooting
 
-Checkout the [troubleshooting](/troubleshooting) for more solutions to common problems.
+Check out [troubleshooting](/troubleshooting) for more solutions to common problems.

--- a/troubleshooting.md
+++ b/troubleshooting.md
@@ -4,12 +4,12 @@
 
 Following a recent [change](https://archlinux.org/news/incoming-changes-in-jdk-jre-21-packages-may-require-manual-intervention/) (2023-11-02) from Arch Linux regarding JDK/JRE packages. You may run into dependency conflicts when updating your BlackArch Linux system and will require manual intervention.
 
-Example of a conflict that may occure during a system update:
+Example of a conflict that may occur during a system update:
 ```shell
 :: removing jre-openjdk breaks the dependency 'jre-openjdk' required by mobsf
 :: removing jre-openjdk breaks the dependency 'jre-openjdk' required by tls-attacker
 ```
-If you have installed BlackArch Linux using one of the currnet ISOs (dated 2023-04-01 or 2023-05-01) or earlier, you will need to execute the following command to address the JDK/JRE conflicts:
+If you have installed BlackArch Linux using one of the current ISOs (dated 2023-04-01 or 2023-05-01) or earlier, you will need to execute the following command to address the JDK/JRE conflicts:
 ```shell
 pacman -Rns mobsf tls-attacker jre-openjdk jdk-openjdk
 pacman -Syyu
@@ -34,7 +34,7 @@ pacman-key --populate
 pacman-key --update --keyserver keyserver.ubuntu.com
 ```
 
-When runnnig system updates, use the `--ignore` flag to exclude gnupg or ignore gnupg in your `pacman.conf` file.
+When running system updates, use the `--ignore` flag to exclude gnupg or ignore gnupg in your `pacman.conf` file.
 
 #### Example 1
 Temporarily ignore the package during system update.
@@ -50,12 +50,12 @@ sed -i '/IgnorePkg/ s/^#//; /IgnorePkg/ s/$/ gnupg/' /etc/pacman.conf
 
 ### Option 2
 
-Add missing key
+Add missing key:
 ```
 echo "F9A6E68A711354D84A9B91637533BAFE69A25079:4:" >> /usr/share/pacman/keyrings/blackarch-trusted
 pacman-key --populate
 ```
-Update the system to verify
+Update the system to verify:
 ```
 pacman -Syu
 ```

--- a/troubleshooting.md
+++ b/troubleshooting.md
@@ -30,7 +30,7 @@ Downgrading to the previous version of GNUPG will resolve your issue.
 pacman -U https://archive.archlinux.org/packages/g/gnupg/gnupg-2.2.41-2-x86_64.pkg.tar.zst
 rm -rf /etc/pacman.d/gnupg
 pacman-key --init
-pacman-key --populate archlinux blackarch
+pacman-key --populate
 pacman-key --update --keyserver keyserver.ubuntu.com
 ```
 

--- a/troubleshooting.md
+++ b/troubleshooting.md
@@ -20,35 +20,9 @@ pacman -S blackarch --needed
 
 After GNUPG updated to version 2.4 in Arch Linux with major upstream changes, there are issues with the blackarch-keyring being corrupted. This prevents you from running the `strap.sh` script, installing BlackArch packages. The team is working on fixing the keyring. 
 
-There are two options to temporarily resolve the issue.
+There is one option to temporarily resolve the issue.
 
 ### Option 1
-
-Downgrading to the previous version of GNUPG will resolve your issue.
-
-```
-pacman -U https://archive.archlinux.org/packages/g/gnupg/gnupg-2.2.41-2-x86_64.pkg.tar.zst
-rm -rf /etc/pacman.d/gnupg
-pacman-key --init
-pacman-key --populate
-pacman-key --update --keyserver keyserver.ubuntu.com
-```
-
-When running system updates, use the `--ignore` flag to exclude gnupg or ignore gnupg in your `pacman.conf` file.
-
-#### Example 1
-Temporarily ignore the package during system update.
-```
-pacman -Syu --ignore gnupg
-```
-
-#### Example 2
-Permanently ignoring the package.
-```
-sed -i '/IgnorePkg/ s/^#//; /IgnorePkg/ s/$/ gnupg/' /etc/pacman.conf
-```
-
-### Option 2
 
 Add missing key:
 ```


### PR DESCRIPTION
Remove `--populate` arguments to run `--populate` by all keyrings. It manages use cases where a system has additional keyrings than `archlinux` and `blackarch`.

Removed old gnupg package option from Wiki because its dependency `libassuan.so=0-64` has been removed from AL repositories:
```
warning: cannot resolve "libassuan.so=0-64", a dependency of "gnupg"
:: The following package cannot be upgraded due to unresolvable dependencies:
      gnupg
```
so that option will be unusable. [strap.sh](https://github.com/BlackArch/blackarch-site/blob/master/strap.sh) does not use it anymore ([evid.](https://github.com/BlackArch/blackarch-site/commit/da3be50969a2355bd91c5981ceae92a97828100a#diff-d48a051b3037fc787441843e0383a1dad747fdb7664b02c1d59184a2881a7c81L189))

It is just to prevent a misusage of wiki like https://github.com/BlackArch/blackarch/issues/4328